### PR TITLE
Add custom root CA support for Keycloak & LDAP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This repository is a single Go module (`go.mod`) with most application code in the root package (`package main`).
+
+- Core sync logic: `app.go`, `diff.go`, `ytsaurus.go`, `azure_real.go`, `ldap.go`, `keycloak.go`
+- Entrypoint and config: `main.go`, `config.go`, `util.go`
+- Tests: `*_test.go` in repo root (`app_*_test.go`, `config_test.go`, `ytsaurus_test.go`)
+- Helm chart: `ytsaurus-identity-sync-chart/` (templates + `values.yaml`)
+- Example values: `examples/*.values.yaml`
+- Example app configs: `*_config.example.yaml`
+
+## Build, Test, and Development Commands
+- `go build -v ./...`: compile all packages (mirrors CI build step).
+- `make test` or `go test ./...`: run the default test suite (includes testcontainers-based tests).
+- `make test-fast`: run tests with `REUSE_YT_CONTAINER=yes` to reuse YTsaurus test container between suite runs.
+- `go test -tags integration ./...`: run integration-tagged tests (requires local secrets/config).
+- `make lint`: run `golangci-lint`.
+- `make lint-fix`: auto-fix supported lint issues.
+- `make format`: run `go fmt`.
+- `go run . --config ./azure_config.example.yaml`: run app with explicit config path.
+
+## Coding Style & Naming Conventions
+Use standard Go formatting and imports (`gofmt` + `goimports`, enforced by lint). Keep files and identifiers idiomatic Go:
+
+- Exported names: `CamelCase`; internal helpers: `camelCase`
+- Test files: `*_test.go`; integration tests are additionally tagged with `//go:build integration`
+- Keep line length reasonable (lint allows up to 240 chars, but prefer readability)
+
+## Testing Guidelines
+Primary framework is Go `testing` with `stretchr/testify` (`require`, `suite`). Prefer table-driven tests for behavior coverage. Keep unit tests runnable via `go test ./...`.
+
+Many tests use Docker/testcontainers; ensure a working local Docker daemon before running `go test ./...`.
+Integration-tagged tests also require local config (`config.local.yaml`, ignored by `*.local.yaml`) and secrets via env vars (for example `AZURE_CLIENT_SECRET`, `YT_TOKEN`).
+
+## Commit & Pull Request Guidelines
+Recent history favors short, imperative commit subjects (e.g., `Refactor keycloak logs`, `Increase keycloak page limit`) with optional issue references like `(#4)`. Conventional style is acceptable when useful (e.g., `feat(keycloak): ...`).
+
+For PRs: include a clear scope summary, linked issue(s), config/chart impact, and test evidence (`go test`, `make lint`). Ensure GitHub Actions checks pass on `main` PRs.

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,18 @@
-.PHONY: lint lint-fix test test-fast format build_images build_helm_chart
+.PHONY: lint lint-fix test test-fast format build build_images build_helm_chart push clean
 
 REGISTRY ?= ghcr.io
 IMAGE_NAME ?= ytsaurus/ytsaurus-identity-sync
 IMAGE_TAG ?= $(shell date -u +%Y-%m-%d)-$(shell git rev-parse --short HEAD)
 IMAGE_REF ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
+DOCKER_CONTEXT ?=
+DOCKER_CONTEXT_ARG := $(if $(strip $(DOCKER_CONTEXT)),--context "$(DOCKER_CONTEXT)",)
 
 CHART_PATH ?= ytsaurus-identity-sync-chart
 CHART_NAME ?= ytsaurus-identity-sync-chart
 CHART_REPOSITORY ?= ytsaurus
-CHART_VERSION ?= 0.0.0-$(IMAGE_TAG)
+CHART_VERSION ?= $(IMAGE_TAG)
 CHART_PACKAGE ?= $(CHART_NAME)-$(CHART_VERSION).tgz
 CHART_REGISTRY ?= oci://$(REGISTRY)/$(CHART_REPOSITORY)
-
-# Set PUSH=true to push built artifacts to registries.
-PUSH ?= false
 
 lint:
 	golangci-lint run
@@ -31,9 +30,23 @@ format:
 	go fmt
 
 build_images:
-	docker build --tag "$(IMAGE_REF)" .
-	@if [ "$(PUSH)" = "true" ]; then docker push "$(IMAGE_REF)"; fi
+	docker $(DOCKER_CONTEXT_ARG) build --tag "$(IMAGE_REF)" .
 
-build_helm_chart:
-	helm package "$(CHART_PATH)" --version "$(CHART_VERSION)"
-	@if [ "$(PUSH)" = "true" ]; then helm push "$(CHART_PACKAGE)" "$(CHART_REGISTRY)"; fi
+build_helm_chart: build_images
+	@TMP_CHART_DIR=$$(mktemp -d); \
+	cp -R "$(CHART_PATH)/." "$$TMP_CHART_DIR/"; \
+	sed 's|^[[:space:]]*tag:[[:space:]]*".*"|  tag: "$(IMAGE_TAG)"|' "$$TMP_CHART_DIR/values.yaml" > "$$TMP_CHART_DIR/values.yaml.tmp"; \
+	mv "$$TMP_CHART_DIR/values.yaml.tmp" "$$TMP_CHART_DIR/values.yaml"; \
+	sed -e 's|^version:.*|version: $(CHART_VERSION)|' \
+		-e 's|^appVersion:.*|appVersion: "$(IMAGE_TAG)"|' \
+		"$$TMP_CHART_DIR/Chart.yaml" > "$$TMP_CHART_DIR/Chart.yaml.tmp"; \
+	mv "$$TMP_CHART_DIR/Chart.yaml.tmp" "$$TMP_CHART_DIR/Chart.yaml"; \
+	helm package "$$TMP_CHART_DIR" --destination . --version "$(CHART_VERSION)"; \
+	rm -rf "$$TMP_CHART_DIR"
+
+push: build_images build_helm_chart
+	docker $(DOCKER_CONTEXT_ARG) push "$(IMAGE_REF)"
+	helm push "$(CHART_PACKAGE)" "$(CHART_REGISTRY)"
+
+clean:
+	rm -f "$(CHART_NAME)-"*.tgz

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,39 @@
-.PHONY: lint
+.PHONY: lint lint-fix test test-fast format build_images build_helm_chart
+
+REGISTRY ?= ghcr.io
+IMAGE_NAME ?= ytsaurus/ytsaurus-identity-sync
+IMAGE_TAG ?= $(shell date -u +%Y-%m-%d)-$(shell git rev-parse --short HEAD)
+IMAGE_REF ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
+
+CHART_PATH ?= ytsaurus-identity-sync-chart
+CHART_NAME ?= ytsaurus-identity-sync-chart
+CHART_REPOSITORY ?= ytsaurus
+CHART_VERSION ?= 0.0.0-$(IMAGE_TAG)
+CHART_PACKAGE ?= $(CHART_NAME)-$(CHART_VERSION).tgz
+CHART_REGISTRY ?= oci://$(REGISTRY)/$(CHART_REPOSITORY)
+
+# Set PUSH=true to push built artifacts to registries.
+PUSH ?= false
+
 lint:
 	golangci-lint run
 
-.PHONY: lint-fix
 lint-fix:
 	golangci-lint run --fix
 
-.PHONY: test
 test:
 	go test ./...
 
-.PHONY: test-fast
 test-fast:
 	REUSE_YT_CONTAINER=yes go test ./...
 
-.PHONY: format
 format:
 	go fmt
+
+build_images:
+	docker build --tag "$(IMAGE_REF)" .
+	@if [ "$(PUSH)" = "true" ]; then docker push "$(IMAGE_REF)"; fi
+
+build_helm_chart:
+	helm package "$(CHART_PATH)" --version "$(CHART_VERSION)"
+	@if [ "$(PUSH)" = "true" ]; then helm push "$(CHART_PACKAGE)" "$(CHART_REGISTRY)"; fi

--- a/config.go
+++ b/config.go
@@ -104,10 +104,13 @@ type LdapConfig struct {
 }
 
 type KeycloakConfig struct {
-	URL                  string `yaml:"url"`
-	Realm                string `yaml:"realm"`
-	ClientID             string `yaml:"client_id"`
-	ClientSecretEnvVar   string `yaml:"client_secret_env_var"`
+	URL                string `yaml:"url"`
+	Realm              string `yaml:"realm"`
+	ClientID           string `yaml:"client_id"`
+	ClientSecretEnvVar string `yaml:"client_secret_env_var"`
+	// CustomRootCAPath is an optional path to PEM-encoded root CA certificate
+	// used to verify Keycloak TLS certificate chain.
+	CustomRootCAPath     string `yaml:"custom_root_ca_path,omitempty"`
 	UsersAttributeFilter string `yaml:"users_attribute_filter"`
 	UsersGroupFilter     string `yaml:"users_group_filter"`
 	GroupsFilter         string `yaml:"groups_filter"`

--- a/config.go
+++ b/config.go
@@ -95,12 +95,15 @@ type LdapGroupsConfig struct {
 }
 
 type LdapConfig struct {
-	Address            string           `yaml:"address"`
-	BindDN             string           `yaml:"bind_dn"`
-	BindPasswordEnvVar string           `yaml:"bind_password_env_var"`
-	Users              LdapUsersConfig  `yaml:"users"`
-	Groups             LdapGroupsConfig `yaml:"groups"`
-	BaseDN             string           `yaml:"base_dn"`
+	Address            string `yaml:"address"`
+	BindDN             string `yaml:"bind_dn"`
+	BindPasswordEnvVar string `yaml:"bind_password_env_var"`
+	// CustomRootCA is an optional path to PEM-encoded root CA certificate
+	// used to verify LDAP TLS certificate chain.
+	CustomRootCA string           `yaml:"custom_root_ca,omitempty"`
+	Users        LdapUsersConfig  `yaml:"users"`
+	Groups       LdapGroupsConfig `yaml:"groups"`
+	BaseDN       string           `yaml:"base_dn"`
 }
 
 type KeycloakConfig struct {
@@ -108,9 +111,9 @@ type KeycloakConfig struct {
 	Realm              string `yaml:"realm"`
 	ClientID           string `yaml:"client_id"`
 	ClientSecretEnvVar string `yaml:"client_secret_env_var"`
-	// CustomRootCAPath is an optional path to PEM-encoded root CA certificate
+	// CustomRootCA is an optional path to PEM-encoded root CA certificate
 	// used to verify Keycloak TLS certificate chain.
-	CustomRootCAPath     string `yaml:"custom_root_ca_path,omitempty"`
+	CustomRootCA         string `yaml:"custom_root_ca,omitempty"`
 	UsersAttributeFilter string `yaml:"users_attribute_filter"`
 	UsersGroupFilter     string `yaml:"users_group_filter"`
 	GroupsFilter         string `yaml:"groups_filter"`

--- a/config_test.go
+++ b/config_test.go
@@ -125,6 +125,7 @@ func TestKeycloakConfig(t *testing.T) {
 	require.Equal(t, "test", cfg.Keycloak.Realm)
 	require.Equal(t, "test", cfg.Keycloak.ClientID)
 	require.Equal(t, "KEYCLOAK_CLIENT_SECRET", cfg.Keycloak.ClientSecretEnvVar)
+	require.Equal(t, "/etc/ytsaurus-identity-sync/keycloak-ca/ca.crt", cfg.Keycloak.CustomRootCAPath)
 	require.Equal(t, "username:test_ email:@acme.com", cfg.Keycloak.UsersAttributeFilter)
 	require.Equal(t, "^test_.*", cfg.Keycloak.UsersGroupFilter)
 	require.Equal(t, "^test_.*", cfg.Keycloak.GroupsFilter)

--- a/config_test.go
+++ b/config_test.go
@@ -76,6 +76,7 @@ func TestLdapConfig(t *testing.T) {
 	require.Equal(t, "cn=admin,dc=example,dc=org", cfg.Ldap.BindDN)
 	require.Equal(t, "localhost:10210", cfg.Ldap.Address)
 	require.Equal(t, "LDAP_PASSWORD", cfg.Ldap.BindPasswordEnvVar)
+	require.Equal(t, "/etc/ytsaurus-identity-sync/ldap-ca/ca.crt", cfg.Ldap.CustomRootCA)
 
 	require.Equal(t, "(&(objectClass=posixAccount)(ou=People))", cfg.Ldap.Users.Filter)
 	require.Equal(t, "cn", cfg.Ldap.Users.UsernameAttributeType)
@@ -125,7 +126,7 @@ func TestKeycloakConfig(t *testing.T) {
 	require.Equal(t, "test", cfg.Keycloak.Realm)
 	require.Equal(t, "test", cfg.Keycloak.ClientID)
 	require.Equal(t, "KEYCLOAK_CLIENT_SECRET", cfg.Keycloak.ClientSecretEnvVar)
-	require.Equal(t, "/etc/ytsaurus-identity-sync/keycloak-ca/ca.crt", cfg.Keycloak.CustomRootCAPath)
+	require.Equal(t, "/etc/ytsaurus-identity-sync/keycloak-ca/ca.crt", cfg.Keycloak.CustomRootCA)
 	require.Equal(t, "username:test_ email:@acme.com", cfg.Keycloak.UsersAttributeFilter)
 	require.Equal(t, "^test_.*", cfg.Keycloak.UsersGroupFilter)
 	require.Equal(t, "^test_.*", cfg.Keycloak.GroupsFilter)

--- a/examples/ytsaurus-identity-sync.keycloak.example.values.yaml
+++ b/examples/ytsaurus-identity-sync.keycloak.example.values.yaml
@@ -11,6 +11,14 @@ syncSource: keycloak
 keycloak:
   # development configuration, use externalSecrets or sealedSecrets for production.
   clientSecret: "keycloak-secret-token"
+  customRootCA:
+    enabled: false
+    # Existing k8s Secret with CA cert in key `ca.crt`.
+    # secretName: "keycloak-root-ca"
+    secretName: ""
+    secretKey: "ca.crt"
+    mountPath: "/etc/ytsaurus-identity-sync/keycloak-ca"
+    fileName: "ca.crt"
 
 syncConfig: |-
   app:
@@ -26,6 +34,8 @@ syncConfig: |-
     realm: "test_realm"
     client_id: "test_client"
     client_secret_env_var: "KEYCLOAK_CLIENT_SECRET"
+    # Enable when Keycloak TLS cert is signed by custom CA and Secret mount is configured above.
+    # custom_root_ca_path: "{{ .Values.keycloak.customRootCA.mountPath }}/{{ .Values.keycloak.customRootCA.fileName }}"
     users_attribute_filter: "username:test_ email:@acme.com"
     users_group_filter: "^test_.*"
     groups_filter: "^test_.*"

--- a/examples/ytsaurus-identity-sync.keycloak.example.values.yaml
+++ b/examples/ytsaurus-identity-sync.keycloak.example.values.yaml
@@ -11,14 +11,11 @@ syncSource: keycloak
 keycloak:
   # development configuration, use externalSecrets or sealedSecrets for production.
   clientSecret: "keycloak-secret-token"
-  customRootCA:
-    enabled: false
-    # Existing k8s Secret with CA cert in key `ca.crt`.
-    # secretName: "keycloak-root-ca"
-    secretName: ""
-    secretKey: "ca.crt"
-    mountPath: "/etc/ytsaurus-identity-sync/keycloak-ca"
-    fileName: "ca.crt"
+  # Optional CA bundle from existing Secret.
+  # caRootBundle:
+  #   kind: Secret
+  #   name: keycloak-root-ca
+  #   key: ca.crt
 
 syncConfig: |-
   app:
@@ -34,8 +31,8 @@ syncConfig: |-
     realm: "test_realm"
     client_id: "test_client"
     client_secret_env_var: "KEYCLOAK_CLIENT_SECRET"
-    # Optional manual override. When keycloak.customRootCA.enabled=true, chart sets this value automatically.
-    # custom_root_ca: "{{ .Values.keycloak.customRootCA.mountPath }}/{{ .Values.keycloak.customRootCA.fileName }}"
+    # Optional manual override. When keycloak.caRootBundle is set, chart sets this value automatically.
+    # custom_root_ca: "/etc/ytsaurus-identity-sync/<keycloak.caRootBundle.key>"
     users_attribute_filter: "username:test_ email:@acme.com"
     users_group_filter: "^test_.*"
     groups_filter: "^test_.*"

--- a/examples/ytsaurus-identity-sync.keycloak.example.values.yaml
+++ b/examples/ytsaurus-identity-sync.keycloak.example.values.yaml
@@ -35,7 +35,7 @@ syncConfig: |-
     client_id: "test_client"
     client_secret_env_var: "KEYCLOAK_CLIENT_SECRET"
     # Enable when Keycloak TLS cert is signed by custom CA and Secret mount is configured above.
-    # custom_root_ca_path: "{{ .Values.keycloak.customRootCA.mountPath }}/{{ .Values.keycloak.customRootCA.fileName }}"
+    # custom_root_ca: "{{ .Values.keycloak.customRootCA.mountPath }}/{{ .Values.keycloak.customRootCA.fileName }}"
     users_attribute_filter: "username:test_ email:@acme.com"
     users_group_filter: "^test_.*"
     groups_filter: "^test_.*"

--- a/examples/ytsaurus-identity-sync.keycloak.example.values.yaml
+++ b/examples/ytsaurus-identity-sync.keycloak.example.values.yaml
@@ -34,7 +34,7 @@ syncConfig: |-
     realm: "test_realm"
     client_id: "test_client"
     client_secret_env_var: "KEYCLOAK_CLIENT_SECRET"
-    # Enable when Keycloak TLS cert is signed by custom CA and Secret mount is configured above.
+    # Optional manual override. When keycloak.customRootCA.enabled=true, chart sets this value automatically.
     # custom_root_ca: "{{ .Values.keycloak.customRootCA.mountPath }}/{{ .Values.keycloak.customRootCA.fileName }}"
     users_attribute_filter: "username:test_ email:@acme.com"
     users_group_filter: "^test_.*"

--- a/examples/ytsaurus-identity-sync.ldap.example.values.yaml
+++ b/examples/ytsaurus-identity-sync.ldap.example.values.yaml
@@ -33,7 +33,7 @@ syncConfig: |-
     address: "localhost:10210"
     bind_dn: "cn=admin,dc=example,dc=org"
     bind_password_env_var: "LDAP_PASSWORD"
-    # Enable when LDAP TLS cert is signed by custom CA and Secret mount is configured above.
+    # Optional manual override. When ldap.customRootCA.enabled=true, chart sets this value automatically.
     # custom_root_ca: "{{ .Values.ldap.customRootCA.mountPath }}/{{ .Values.ldap.customRootCA.fileName }}"
     base_dn: "dc=example,dc=org"
     users:

--- a/examples/ytsaurus-identity-sync.ldap.example.values.yaml
+++ b/examples/ytsaurus-identity-sync.ldap.example.values.yaml
@@ -11,14 +11,11 @@ syncSource: ldap
 ldap:
   # development configuration, use externalSecrets or sealedSecrets for production.
   password: "ldap-password"
-  customRootCA:
-    enabled: false
-    # Existing k8s Secret with CA cert in key `ca.crt`.
-    # secretName: "ldap-root-ca"
-    secretName: ""
-    secretKey: "ca.crt"
-    mountPath: "/etc/ytsaurus-identity-sync/ldap-ca"
-    fileName: "ca.crt"
+  # Optional CA bundle from existing Secret.
+  # caRootBundle:
+  #   kind: Secret
+  #   name: ldap-root-ca
+  #   key: ca.crt
 
 syncConfig: |-
   app:
@@ -33,8 +30,8 @@ syncConfig: |-
     address: "localhost:10210"
     bind_dn: "cn=admin,dc=example,dc=org"
     bind_password_env_var: "LDAP_PASSWORD"
-    # Optional manual override. When ldap.customRootCA.enabled=true, chart sets this value automatically.
-    # custom_root_ca: "{{ .Values.ldap.customRootCA.mountPath }}/{{ .Values.ldap.customRootCA.fileName }}"
+    # Optional manual override. When ldap.caRootBundle is set, chart sets this value automatically.
+    # custom_root_ca: "/etc/ytsaurus-identity-sync/<ldap.caRootBundle.key>"
     base_dn: "dc=example,dc=org"
     users:
       filter: "(&(objectClass=posixAccount)(ou=People))"

--- a/examples/ytsaurus-identity-sync.ldap.example.values.yaml
+++ b/examples/ytsaurus-identity-sync.ldap.example.values.yaml
@@ -11,6 +11,14 @@ syncSource: ldap
 ldap:
   # development configuration, use externalSecrets or sealedSecrets for production.
   password: "ldap-password"
+  customRootCA:
+    enabled: false
+    # Existing k8s Secret with CA cert in key `ca.crt`.
+    # secretName: "ldap-root-ca"
+    secretName: ""
+    secretKey: "ca.crt"
+    mountPath: "/etc/ytsaurus-identity-sync/ldap-ca"
+    fileName: "ca.crt"
 
 syncConfig: |-
   app:
@@ -25,6 +33,8 @@ syncConfig: |-
     address: "localhost:10210"
     bind_dn: "cn=admin,dc=example,dc=org"
     bind_password_env_var: "LDAP_PASSWORD"
+    # Enable when LDAP TLS cert is signed by custom CA and Secret mount is configured above.
+    # custom_root_ca: "{{ .Values.ldap.customRootCA.mountPath }}/{{ .Values.ldap.customRootCA.fileName }}"
     base_dn: "dc=example,dc=org"
     users:
       filter: "(&(objectClass=posixAccount)(ou=People))"

--- a/keycloak.go
+++ b/keycloak.go
@@ -3,8 +3,6 @@ package main
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
-	"os"
 	"strings"
 
 	"github.com/Nerzal/gocloak/v14"
@@ -60,24 +58,13 @@ func NewKeycloak(cfg *KeycloakConfig, logger appLoggerType) (*Keycloak, error) {
 }
 
 func configureKeycloakTLSClient(client *gocloak.GoCloak, cfg *KeycloakConfig) error {
-	if cfg.CustomRootCAPath == "" {
+	if cfg.CustomRootCA == "" {
 		return nil
 	}
 
-	customRootCA, err := os.ReadFile(cfg.CustomRootCAPath)
+	rootCAs, err := loadCustomRootCAs(cfg.CustomRootCA, "keycloak")
 	if err != nil {
-		return errors.Wrapf(err, "failed to read keycloak custom root CA from %s", cfg.CustomRootCAPath)
-	}
-
-	rootCAs, err := x509.SystemCertPool()
-	if err != nil {
-		return errors.Wrap(err, "failed to load system certificate pool")
-	}
-	if rootCAs == nil {
-		rootCAs = x509.NewCertPool()
-	}
-	if ok := rootCAs.AppendCertsFromPEM(customRootCA); !ok {
-		return errors.Errorf("failed to parse keycloak custom root CA from %s", cfg.CustomRootCAPath)
+		return err
 	}
 
 	client.RestyClient().SetTLSClientConfig(&tls.Config{RootCAs: rootCAs})

--- a/keycloak.go
+++ b/keycloak.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"os"
 	"strings"
 
 	"github.com/Nerzal/gocloak/v14"
@@ -33,6 +36,10 @@ type AttributeFilter struct {
 
 func NewKeycloak(cfg *KeycloakConfig, logger appLoggerType) (*Keycloak, error) {
 	client := gocloak.NewClient(cfg.URL)
+	err := configureKeycloakTLSClient(client, cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	usersGroupfilter, err := regexp2.Compile(cfg.UsersGroupFilter, 0)
 	if err != nil {
@@ -50,6 +57,31 @@ func NewKeycloak(cfg *KeycloakConfig, logger appLoggerType) (*Keycloak, error) {
 		groupsFilter:     groupsFilter,
 		logger:           logger,
 	}, nil
+}
+
+func configureKeycloakTLSClient(client *gocloak.GoCloak, cfg *KeycloakConfig) error {
+	if cfg.CustomRootCAPath == "" {
+		return nil
+	}
+
+	customRootCA, err := os.ReadFile(cfg.CustomRootCAPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read keycloak custom root CA from %s", cfg.CustomRootCAPath)
+	}
+
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		return errors.Wrap(err, "failed to load system certificate pool")
+	}
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+	if ok := rootCAs.AppendCertsFromPEM(customRootCA); !ok {
+		return errors.Errorf("failed to parse keycloak custom root CA from %s", cfg.CustomRootCAPath)
+	}
+
+	client.RestyClient().SetTLSClientConfig(&tls.Config{RootCAs: rootCAs})
+	return nil
 }
 
 func (k *Keycloak) CreateUserFromRaw(raw map[string]any) (SourceUser, error) {

--- a/keycloak_config.example.yaml
+++ b/keycloak_config.example.yaml
@@ -16,7 +16,7 @@ keycloak:
   realm: "test"
   client_id: "test"
   client_secret_env_var: "KEYCLOAK_CLIENT_SECRET"
-  custom_root_ca_path: "/etc/ytsaurus-identity-sync/keycloak-ca/ca.crt" # optional
+  custom_root_ca: "/etc/ytsaurus-identity-sync/keycloak-ca/ca.crt" # optional
   users_attribute_filter: "username:test_ email:@acme.com" # attributes search filter https://www.keycloak.org/docs/latest/server_admin/index.html#listing-users
   users_group_filter: "^test_.*" # regexp filter
   groups_filter: "^test_.*" # regexp filter

--- a/keycloak_config.example.yaml
+++ b/keycloak_config.example.yaml
@@ -16,6 +16,7 @@ keycloak:
   realm: "test"
   client_id: "test"
   client_secret_env_var: "KEYCLOAK_CLIENT_SECRET"
+  custom_root_ca_path: "/etc/ytsaurus-identity-sync/keycloak-ca/ca.crt" # optional
   users_attribute_filter: "username:test_ email:@acme.com" # attributes search filter https://www.keycloak.org/docs/latest/server_admin/index.html#listing-users
   users_group_filter: "^test_.*" # regexp filter
   groups_filter: "^test_.*" # regexp filter

--- a/keycloak_tls_test.go
+++ b/keycloak_tls_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func keycloakTestConfig() *KeycloakConfig {
+	return &KeycloakConfig{
+		URL:                "https://keycloak.example.com",
+		Realm:              "test",
+		ClientID:           "test-client",
+		ClientSecretEnvVar: "KEYCLOAK_CLIENT_SECRET",
+		UsersGroupFilter:   ".*",
+		GroupsFilter:       ".*",
+	}
+}
+
+func TestNewKeycloakWithMissingCustomRootCA(t *testing.T) {
+	cfg := keycloakTestConfig()
+	cfg.CustomRootCAPath = "/no/such/custom-ca.pem"
+
+	_, err := NewKeycloak(cfg, getDevelopmentLogger())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read keycloak custom root CA")
+}
+
+func TestNewKeycloakWithInvalidCustomRootCA(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "keycloak-custom-ca-*.pem")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("not-a-pem")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	cfg := keycloakTestConfig()
+	cfg.CustomRootCAPath = tmpFile.Name()
+
+	_, err = NewKeycloak(cfg, getDevelopmentLogger())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse keycloak custom root CA")
+}

--- a/keycloak_tls_test.go
+++ b/keycloak_tls_test.go
@@ -20,7 +20,7 @@ func keycloakTestConfig() *KeycloakConfig {
 
 func TestNewKeycloakWithMissingCustomRootCA(t *testing.T) {
 	cfg := keycloakTestConfig()
-	cfg.CustomRootCAPath = "/no/such/custom-ca.pem"
+	cfg.CustomRootCA = "/no/such/custom-ca.pem"
 
 	_, err := NewKeycloak(cfg, getDevelopmentLogger())
 	require.Error(t, err)
@@ -37,7 +37,7 @@ func TestNewKeycloakWithInvalidCustomRootCA(t *testing.T) {
 	require.NoError(t, tmpFile.Close())
 
 	cfg := keycloakTestConfig()
-	cfg.CustomRootCAPath = tmpFile.Name()
+	cfg.CustomRootCA = tmpFile.Name()
 
 	_, err = NewKeycloak(cfg, getDevelopmentLogger())
 	require.Error(t, err)

--- a/ldap.go
+++ b/ldap.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/tls"
+
 	"github.com/go-ldap/ldap/v3"
 	"k8s.io/utils/env"
 )
@@ -12,7 +14,12 @@ type Ldap struct {
 }
 
 func NewLdap(cfg *LdapConfig, logger appLoggerType) (*Ldap, error) {
-	conn, err := ldap.DialURL(cfg.Address)
+	dialOpts, err := makeLDAPDialOptions(cfg.CustomRootCA)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := ldap.DialURL(cfg.Address, dialOpts...)
 	if err != nil {
 		logger.Fatalf("Failed to connect: %s\n", err)
 		return nil, err
@@ -30,6 +37,21 @@ func NewLdap(cfg *LdapConfig, logger appLoggerType) (*Ldap, error) {
 		connection: conn,
 		config:     cfg,
 		logger:     logger,
+	}, nil
+}
+
+func makeLDAPDialOptions(customRootCAPath string) ([]ldap.DialOpt, error) {
+	if customRootCAPath == "" {
+		return nil, nil
+	}
+
+	rootCAs, err := loadCustomRootCAs(customRootCAPath, "ldap")
+	if err != nil {
+		return nil, err
+	}
+
+	return []ldap.DialOpt{
+		ldap.DialWithTLSConfig(&tls.Config{RootCAs: rootCAs}),
 	}, nil
 }
 

--- a/ldap_config.example.yaml
+++ b/ldap_config.example.yaml
@@ -15,6 +15,7 @@ ldap:
   address: "localhost:10210"
   bind_dn: "cn=admin,dc=example,dc=org"
   bind_password_env_var: "LDAP_PASSWORD"
+  custom_root_ca: "/etc/ytsaurus-identity-sync/ldap-ca/ca.crt" # optional
   base_dn: "dc=example,dc=org"
   users:
     filter: "(&(objectClass=posixAccount)(ou=People))"

--- a/ldap_tls_test.go
+++ b/ldap_tls_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeLDAPDialOptionsWithMissingCustomRootCA(t *testing.T) {
+	_, err := makeLDAPDialOptions("/no/such/custom-ca.pem")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read ldap custom root CA")
+}
+
+func TestMakeLDAPDialOptionsWithInvalidCustomRootCA(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "ldap-custom-ca-*.pem")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("not-a-pem")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	_, err = makeLDAPDialOptions(tmpFile.Name())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse ldap custom root CA")
+}

--- a/tls_custom_root_ca.go
+++ b/tls_custom_root_ca.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"crypto/x509"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+func loadCustomRootCAs(customRootCAPath string, sourceName string) (*x509.CertPool, error) {
+	customRootCA, err := os.ReadFile(customRootCAPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read %s custom root CA from %s", sourceName, customRootCAPath)
+	}
+
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load system certificate pool")
+	}
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+	if ok := rootCAs.AppendCertsFromPEM(customRootCA); !ok {
+		return nil, errors.Errorf("failed to parse %s custom root CA from %s", sourceName, customRootCAPath)
+	}
+
+	return rootCAs, nil
+}

--- a/ytsaurus-identity-sync-chart/templates/configmap.yaml
+++ b/ytsaurus-identity-sync-chart/templates/configmap.yaml
@@ -1,13 +1,15 @@
 {{- $syncConfigRendered := tpl (required "syncConfig is not provided" .Values.syncConfig) . -}}
 {{- $syncConfig := fromYaml $syncConfigRendered | default (dict) -}}
-{{- if and (eq .Values.syncSource "ldap") .Values.ldap.customRootCA.enabled -}}
+{{- if and (eq .Values.syncSource "ldap") .Values.ldap.caRootBundle -}}
 {{- $ldapCfg := (index $syncConfig "ldap") | default (dict) -}}
-{{- $_ := set $ldapCfg "custom_root_ca" (printf "%s/%s" (trimSuffix "/" (required "ldap.customRootCA.mountPath is not provided" .Values.ldap.customRootCA.mountPath)) (required "ldap.customRootCA.fileName is not provided" .Values.ldap.customRootCA.fileName)) -}}
+{{- $ldapCAKey := required "ldap.caRootBundle.key is not provided" .Values.ldap.caRootBundle.key -}}
+{{- $_ := set $ldapCfg "custom_root_ca" (printf "/etc/ytsaurus-identity-sync/%s" $ldapCAKey) -}}
 {{- $_ := set $syncConfig "ldap" $ldapCfg -}}
 {{- end -}}
-{{- if and (eq .Values.syncSource "keycloak") .Values.keycloak.customRootCA.enabled -}}
+{{- if and (eq .Values.syncSource "keycloak") .Values.keycloak.caRootBundle -}}
 {{- $keycloakCfg := (index $syncConfig "keycloak") | default (dict) -}}
-{{- $_ := set $keycloakCfg "custom_root_ca" (printf "%s/%s" (trimSuffix "/" (required "keycloak.customRootCA.mountPath is not provided" .Values.keycloak.customRootCA.mountPath)) (required "keycloak.customRootCA.fileName is not provided" .Values.keycloak.customRootCA.fileName)) -}}
+{{- $keycloakCAKey := required "keycloak.caRootBundle.key is not provided" .Values.keycloak.caRootBundle.key -}}
+{{- $_ := set $keycloakCfg "custom_root_ca" (printf "/etc/ytsaurus-identity-sync/%s" $keycloakCAKey) -}}
 {{- $_ := set $syncConfig "keycloak" $keycloakCfg -}}
 {{- end -}}
 apiVersion: v1

--- a/ytsaurus-identity-sync-chart/templates/configmap.yaml
+++ b/ytsaurus-identity-sync-chart/templates/configmap.yaml
@@ -1,3 +1,15 @@
+{{- $syncConfigRendered := tpl (required "syncConfig is not provided" .Values.syncConfig) . -}}
+{{- $syncConfig := fromYaml $syncConfigRendered | default (dict) -}}
+{{- if and (eq .Values.syncSource "ldap") .Values.ldap.customRootCA.enabled -}}
+{{- $ldapCfg := (index $syncConfig "ldap") | default (dict) -}}
+{{- $_ := set $ldapCfg "custom_root_ca" (printf "%s/%s" (trimSuffix "/" (required "ldap.customRootCA.mountPath is not provided" .Values.ldap.customRootCA.mountPath)) (required "ldap.customRootCA.fileName is not provided" .Values.ldap.customRootCA.fileName)) -}}
+{{- $_ := set $syncConfig "ldap" $ldapCfg -}}
+{{- end -}}
+{{- if and (eq .Values.syncSource "keycloak") .Values.keycloak.customRootCA.enabled -}}
+{{- $keycloakCfg := (index $syncConfig "keycloak") | default (dict) -}}
+{{- $_ := set $keycloakCfg "custom_root_ca" (printf "%s/%s" (trimSuffix "/" (required "keycloak.customRootCA.mountPath is not provided" .Values.keycloak.customRootCA.mountPath)) (required "keycloak.customRootCA.fileName is not provided" .Values.keycloak.customRootCA.fileName)) -}}
+{{- $_ := set $syncConfig "keycloak" $keycloakCfg -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,4 +18,4 @@ metadata:
     {{- include "ytsaurus-identity-sync.labels" . | nindent 4 }}
 data:
   config.yaml: |-
-    {{- tpl (required "syncConfig is not provided" .Values.syncConfig) . | nindent 4 }}
+    {{- toYaml $syncConfig | nindent 4 }}

--- a/ytsaurus-identity-sync-chart/templates/deployment.yaml
+++ b/ytsaurus-identity-sync-chart/templates/deployment.yaml
@@ -77,6 +77,11 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/ytsaurus-identity-sync
+            {{- if and (eq .Values.syncSource "ldap") .Values.ldap.customRootCA.enabled }}
+            - name: ldap-custom-root-ca
+              mountPath: {{ required "ldap.customRootCA.mountPath is not provided" .Values.ldap.customRootCA.mountPath | quote }}
+              readOnly: true
+            {{- end }}
             {{- if and (eq .Values.syncSource "keycloak") .Values.keycloak.customRootCA.enabled }}
             - name: keycloak-custom-root-ca
               mountPath: {{ required "keycloak.customRootCA.mountPath is not provided" .Values.keycloak.customRootCA.mountPath | quote }}
@@ -92,6 +97,14 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+        {{- if and (eq .Values.syncSource "ldap") .Values.ldap.customRootCA.enabled }}
+        - name: ldap-custom-root-ca
+          secret:
+            secretName: {{ required "ldap.customRootCA.secretName is not provided" .Values.ldap.customRootCA.secretName | quote }}
+            items:
+              - key: {{ required "ldap.customRootCA.secretKey is not provided" .Values.ldap.customRootCA.secretKey | quote }}
+                path: {{ required "ldap.customRootCA.fileName is not provided" .Values.ldap.customRootCA.fileName | quote }}
+        {{- end }}
         {{- if and (eq .Values.syncSource "keycloak") .Values.keycloak.customRootCA.enabled }}
         - name: keycloak-custom-root-ca
           secret:

--- a/ytsaurus-identity-sync-chart/templates/deployment.yaml
+++ b/ytsaurus-identity-sync-chart/templates/deployment.yaml
@@ -77,6 +77,11 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/ytsaurus-identity-sync
+            {{- if and (eq .Values.syncSource "keycloak") .Values.keycloak.customRootCA.enabled }}
+            - name: keycloak-custom-root-ca
+              mountPath: {{ required "keycloak.customRootCA.mountPath is not provided" .Values.keycloak.customRootCA.mountPath | quote }}
+              readOnly: true
+            {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -87,6 +92,14 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+        {{- if and (eq .Values.syncSource "keycloak") .Values.keycloak.customRootCA.enabled }}
+        - name: keycloak-custom-root-ca
+          secret:
+            secretName: {{ required "keycloak.customRootCA.secretName is not provided" .Values.keycloak.customRootCA.secretName | quote }}
+            items:
+              - key: {{ required "keycloak.customRootCA.secretKey is not provided" .Values.keycloak.customRootCA.secretKey | quote }}
+                path: {{ required "keycloak.customRootCA.fileName is not provided" .Values.keycloak.customRootCA.fileName | quote }}
+        {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/ytsaurus-identity-sync-chart/templates/deployment.yaml
+++ b/ytsaurus-identity-sync-chart/templates/deployment.yaml
@@ -77,14 +77,24 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/ytsaurus-identity-sync
-            {{- if and (eq .Values.syncSource "ldap") .Values.ldap.customRootCA.enabled }}
-            - name: ldap-custom-root-ca
-              mountPath: {{ required "ldap.customRootCA.mountPath is not provided" .Values.ldap.customRootCA.mountPath | quote }}
+            {{- if and (eq .Values.syncSource "ldap") .Values.ldap.caRootBundle }}
+            {{- if ne (required "ldap.caRootBundle.kind is not provided" .Values.ldap.caRootBundle.kind) "Secret" }}
+            {{- fail "ldap.caRootBundle.kind must be Secret" }}
+            {{- end }}
+            {{- $ldapCAKey := required "ldap.caRootBundle.key is not provided" .Values.ldap.caRootBundle.key }}
+            - name: ldap-ca-root-bundle
+              mountPath: {{ printf "/etc/ytsaurus-identity-sync/%s" $ldapCAKey | quote }}
+              subPath: {{ $ldapCAKey | quote }}
               readOnly: true
             {{- end }}
-            {{- if and (eq .Values.syncSource "keycloak") .Values.keycloak.customRootCA.enabled }}
-            - name: keycloak-custom-root-ca
-              mountPath: {{ required "keycloak.customRootCA.mountPath is not provided" .Values.keycloak.customRootCA.mountPath | quote }}
+            {{- if and (eq .Values.syncSource "keycloak") .Values.keycloak.caRootBundle }}
+            {{- if ne (required "keycloak.caRootBundle.kind is not provided" .Values.keycloak.caRootBundle.kind) "Secret" }}
+            {{- fail "keycloak.caRootBundle.kind must be Secret" }}
+            {{- end }}
+            {{- $keycloakCAKey := required "keycloak.caRootBundle.key is not provided" .Values.keycloak.caRootBundle.key }}
+            - name: keycloak-ca-root-bundle
+              mountPath: {{ printf "/etc/ytsaurus-identity-sync/%s" $keycloakCAKey | quote }}
+              subPath: {{ $keycloakCAKey | quote }}
               readOnly: true
             {{- end }}
           {{- with .Values.volumeMounts }}
@@ -97,21 +107,29 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
-        {{- if and (eq .Values.syncSource "ldap") .Values.ldap.customRootCA.enabled }}
-        - name: ldap-custom-root-ca
-          secret:
-            secretName: {{ required "ldap.customRootCA.secretName is not provided" .Values.ldap.customRootCA.secretName | quote }}
-            items:
-              - key: {{ required "ldap.customRootCA.secretKey is not provided" .Values.ldap.customRootCA.secretKey | quote }}
-                path: {{ required "ldap.customRootCA.fileName is not provided" .Values.ldap.customRootCA.fileName | quote }}
+        {{- if and (eq .Values.syncSource "ldap") .Values.ldap.caRootBundle }}
+        {{- if ne (required "ldap.caRootBundle.kind is not provided" .Values.ldap.caRootBundle.kind) "Secret" }}
+        {{- fail "ldap.caRootBundle.kind must be Secret" }}
         {{- end }}
-        {{- if and (eq .Values.syncSource "keycloak") .Values.keycloak.customRootCA.enabled }}
-        - name: keycloak-custom-root-ca
+        {{- $ldapCAKey := required "ldap.caRootBundle.key is not provided" .Values.ldap.caRootBundle.key }}
+        - name: ldap-ca-root-bundle
           secret:
-            secretName: {{ required "keycloak.customRootCA.secretName is not provided" .Values.keycloak.customRootCA.secretName | quote }}
+            secretName: {{ required "ldap.caRootBundle.name is not provided" .Values.ldap.caRootBundle.name | quote }}
             items:
-              - key: {{ required "keycloak.customRootCA.secretKey is not provided" .Values.keycloak.customRootCA.secretKey | quote }}
-                path: {{ required "keycloak.customRootCA.fileName is not provided" .Values.keycloak.customRootCA.fileName | quote }}
+              - key: {{ $ldapCAKey | quote }}
+                path: {{ $ldapCAKey | quote }}
+        {{- end }}
+        {{- if and (eq .Values.syncSource "keycloak") .Values.keycloak.caRootBundle }}
+        {{- if ne (required "keycloak.caRootBundle.kind is not provided" .Values.keycloak.caRootBundle.kind) "Secret" }}
+        {{- fail "keycloak.caRootBundle.kind must be Secret" }}
+        {{- end }}
+        {{- $keycloakCAKey := required "keycloak.caRootBundle.key is not provided" .Values.keycloak.caRootBundle.key }}
+        - name: keycloak-ca-root-bundle
+          secret:
+            secretName: {{ required "keycloak.caRootBundle.name is not provided" .Values.keycloak.caRootBundle.name | quote }}
+            items:
+              - key: {{ $keycloakCAKey | quote }}
+                path: {{ $keycloakCAKey | quote }}
         {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/ytsaurus-identity-sync-chart/values.yaml
+++ b/ytsaurus-identity-sync-chart/values.yaml
@@ -75,6 +75,14 @@ syncSource: azure
 
 ldap:
   password: "not-here"
+  customRootCA:
+    enabled: false
+    # Existing Secret with CA certificate in PEM format.
+    secretName: ""
+    # Key in the Secret that stores certificate content.
+    secretKey: "ca.crt"
+    mountPath: "/etc/ytsaurus-identity-sync/ldap-ca"
+    fileName: "ca.crt"
 
 azure:
   clientSecret: "not-here"

--- a/ytsaurus-identity-sync-chart/values.yaml
+++ b/ytsaurus-identity-sync-chart/values.yaml
@@ -75,28 +75,20 @@ syncSource: azure
 
 ldap:
   password: "not-here"
-  customRootCA:
-    enabled: false
-    # Existing Secret with CA certificate in PEM format.
-    secretName: ""
-    # Key in the Secret that stores certificate content.
-    secretKey: "ca.crt"
-    mountPath: "/etc/ytsaurus-identity-sync/ldap-ca"
-    fileName: "ca.crt"
+  # caRootBundle:
+  #   kind: Secret
+  #   name: secret-name
+  #   key: ca.crt
 
 azure:
   clientSecret: "not-here"
 
 keycloak:
   clientSecret: "not-here"
-  customRootCA:
-    enabled: false
-    # Existing Secret with CA certificate in PEM format.
-    secretName: ""
-    # Key in the Secret that stores certificate content.
-    secretKey: "ca.crt"
-    mountPath: "/etc/ytsaurus-identity-sync/keycloak-ca"
-    fileName: "ca.crt"
+  # caRootBundle:
+  #   kind: Secret
+  #   name: secret-name
+  #   key: ca.crt
 
 # not recommended for production environment
 plainSecrets:

--- a/ytsaurus-identity-sync-chart/values.yaml
+++ b/ytsaurus-identity-sync-chart/values.yaml
@@ -81,6 +81,14 @@ azure:
 
 keycloak:
   clientSecret: "not-here"
+  customRootCA:
+    enabled: false
+    # Existing Secret with CA certificate in PEM format.
+    secretName: ""
+    # Key in the Secret that stores certificate content.
+    secretKey: "ca.crt"
+    mountPath: "/etc/ytsaurus-identity-sync/keycloak-ca"
+    fileName: "ca.crt"
 
 # not recommended for production environment
 plainSecrets:


### PR DESCRIPTION
## Summary
- add optional `custom_root_ca` to `keycloak` and `ldap` configs (no Azure changes)
- extend Helm chart values/templates to mount custom CA Secret for LDAP (Keycloak support is kept)
- add `AGENTS.md` contributor guide
- improve Makefile workflow for image/chart build+push, Docker daemon context support, and chart metadata/image tag stamping at package time
 